### PR TITLE
Update generate_training_set.py

### DIFF
--- a/generate_training_set.py
+++ b/generate_training_set.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import os
+import chess
 import chess.pgn
 import numpy as np
 from state import State
+from pathlib import Path
 
 def get_dataset(num_samples=None):
   X,Y = [], []
@@ -29,6 +31,8 @@ def get_dataset(num_samples=None):
       if num_samples is not None and len(X) > num_samples:
         return X,Y
       gn += 1
+except IOError as e:
+            print(f"Error processing file {file_path}: {str(e)}")    
   X = np.array(X)
   Y = np.array(Y)
   return X,Y


### PR DESCRIPTION
The code imports the chess.pgn module but does not import the chess module itself. Added import chess to avoid any potential import errors.  IOError displays an error message when a file cannot be opened or read.

Possible changes:
-When parsing chess moves using game.mainline_moves(), there's a possibility of encountering an AssertionError if the move is not legal on the current board. You can handle this exception and continue to the next move, displaying an error message. 
-You could use the pathlib module for file path manipulation: Instead of using os.path functions